### PR TITLE
Update GoogleChartsHelper.php

### DIFF
--- a/View/Helper/GoogleChartsHelper.php
+++ b/View/Helper/GoogleChartsHelper.php
@@ -74,7 +74,7 @@ class GoogleChartsHelper extends AppHelper
             $this->libraryLoaded = true;
 
             //JS to load
-            $js = 'google.load("visualization", "1", {packages:["corechart", "gauge", "calendar", "table"]});';
+            $js = 'google.load("visualization", "1", {packages:["corechart", "gauge", "calendar", "table", "orgchart"]});';
 
             //create an array of charts to load more than one
             $js .= "var charts = new Array();";
@@ -140,6 +140,10 @@ class GoogleChartsHelper extends AppHelper
                 if ($chart->columns[$columnKeys[$rKey]]['type'] === "string")
                 {
                     $jsVal = "'{$val}'";
+                }
+                if ($chart->columns[$columnKeys[$rKey]]['type'] === "array")
+                {
+                    $jsVal = json_encode($val);
                 }
                 if ($val === null)
                 {


### PR DESCRIPTION
Update to handle 'array' column type. Use case: '[Org Chart Type](https://developers.google.com/chart/interactive/docs/gallery/orgchart)', with `v` and `f` format data.
Example data (from the Google Charts page): 

```
          [{v:'Mike', f:'Mike<div style="color:red; font-style:italic">President</div>'},
           '', 'The President'],
          [{v:'Jim', f:'Jim<div style="color:red; font-style:italic">Vice President</div>'},
           'Mike', 'VP'],
          ['Alice', 'Mike', ''],
          ['Bob', 'Jim', 'Bob Sponge'],
          ['Carol', 'Bob', '']
```

From Controller, the following code works now:

```
       $chart->columns(array(
            //Each column key should correspond to a field in your data array
            'name' => array(
                //Tells the chart what type of data this is
                'type' => 'array',     
                //The chart label for this column           
                'label' => 'Name'
            ),
            'manager' => array(
                //Tells the chart what type of data this is
                'type' => 'string',     
                //The chart label for this column           
                'label' => 'Manager'
            )
        ));
         foreach($users as $user){
            //$chart->addRow($user['User']);
            $name = array();
            $name['v'] = $user['User']['name'];
            $name['f'] = $user['User']['name'].'<div class="text-muted text-info">'.$user['Role']['name'].'</div>';

            $chart->addRow( array('name' => $name, 'manager' => $user['Manager']['name']) );
        }
```
